### PR TITLE
[WIP] README.mdデータベース設計を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,55 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+# CHAT-SPACE DB設計
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index: ture, null: false, unique: true|
+|email|string|null: null: false, unique: true|
+|password|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has many :groups, through: groups_users
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has many :users, through: groups_users
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+# messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text||
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -68,8 +68,8 @@ Things you may want to cover:
 |------|----|-------|
 |body|text||
 |image|string||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group


### PR DESCRIPTION
#WHAT

　README.mbにデータベース設計について記載した。
　　＠初期画面で,e-mail,name,password
　　＠ログイン後のグループ作成画面では、グループ名、追加したいname,自分のname
　　＠投稿画面では、内容、画像追加、自分のname,登録されたname
　があったので、user,group,messegeと中間テーブル（userとgroup用）を作成した。

　全体に空入力防止やuser.name,user.e-mail, group.nameは重複できないようにした。

#WHY
　データベース設計はサービスやシステムの開発の最初の段階で行う必要があるため。


※作業方法について確認したいことがあります。
　　最初は、mac内のフォルダ内にあるREADMEをVSコードで編集していました。
　　完成後、気づいたのですが、これはマスターでの処理と同じと考えて良いのでしょう　
　　か？
　　というのもGITHUBデスクトップを開いたところ、マスターブランチのチェンジ項目に
　　README.mbがあったので。
　　最終的に、コマンド＋Zで元に戻し、ブラウザ上のgithub,comのトピックブランチ内
　　にあるREADME.mb上で編集を行いました。


　　今後、トピックブランチを編集する場合は、ブラウザ上で行うということでしょうか？
